### PR TITLE
Fix `ProducStageBlockTest`

### DIFF
--- a/src/test/java/org/openlca/simapro/csv/ProductStageBlockTest.java
+++ b/src/test/java/org/openlca/simapro/csv/ProductStageBlockTest.java
@@ -155,6 +155,7 @@ public class ProductStageBlockTest {
           .comment(""));
 
         var referenceAssembly = productStage.assembly();
+        assertEquals("assembly", referenceAssembly.name());
         assertEquals(1, referenceAssembly.amount().value(), 0.0001);
         assertEquals("p", referenceAssembly.unit());
         assertTrue(referenceAssembly.uncertainty().isUndefined());


### PR DESCRIPTION
There was no problems with Product Stage IO implementation. So this PR fix `ProducStageBlockTest` errors:
* Errors from copy/paste code (Lines 52, 61, 64, 65 and 121)
* An error from mistaking `wasteScenarios()` and `wasteOrDisposalScenario()`.